### PR TITLE
Individual months per row on mobile, form titles next to fields, mino…

### DIFF
--- a/md_scheduler/scheduler/static/css/scheduler.css
+++ b/md_scheduler/scheduler/static/css/scheduler.css
@@ -3,10 +3,24 @@ body {
   padding-top: 60px;
 }
 
-@media (max-width: 979px) {
+@media only screen and (max-width: 810px) {
   body {
     padding-top: 50px;
   }
+}
+
+.content-mobile {
+    display: none !important;
+}
+
+@media only screen and (max-width: 810px) {
+    .content-desktop {
+        display: none !important;
+    }
+
+    .content-mobile {
+        display: inline !important;
+    }
 }
 
 .spacer20 { 
@@ -101,6 +115,14 @@ textarea.form-control {
     text-align: right !important;
 }
 
+.float-r {
+    float: right;
+}
+
+.float-l {
+    float: left;
+}
+
 .activity {
     padding-top: 1em;
     padding-left: 1em;
@@ -112,6 +134,10 @@ textarea.form-control {
     padding-left: 1em;
     padding-right: 1em;
     color: #BF9B19;
+}
+
+.txt-gold {
+    color: #BF9B19
 }
 
 .add_link {

--- a/md_scheduler/scheduler/templates/scheduler/index.html
+++ b/md_scheduler/scheduler/templates/scheduler/index.html
@@ -4,8 +4,9 @@
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{% static 'css/scheduler.css' %}">
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css">
     <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/hammer.js/2.0.8/hammer.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
     <script src="{% static 'js/scheduler.js' %}"></script>
 
@@ -53,7 +54,7 @@
         <div class="spacer20"></div>
 
         {# next, prev navigation #}
-        <div class="row">
+        <div class="row content-desktop">
             <div class="col-md-3">
             </div>
             <div class="col-md-2">
@@ -67,191 +68,338 @@
             </div>
         </div>
 
+        {# next, prev navigation #}
+        <div class="row content-mobile">
+            <div class="col-md-2 center">
+                <a href="#" class="prev_program float-l">&larr; Previous</a>
+                <span class="program_index">&nbsp;</span>
+                <a href="#" class="next_program float-r">Next &rarr;</a>
+            </div>
+        </div>
+
         {# calendar #}
         <div id="schedule">
 
-            {# row 1 months #}
-            <div class="row">
+            <div class="content-desktop">
+                {# row 1 months #}
+                <div class="row">
+                    {% for month in row_1_months %}
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# row 1 weeks #}
+                <div class="row">
+                    {% for month in row_1_months %}
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                {# row 1 classes #}
+                <div class="row row_1">
+                    {% for month in row_1_months %}
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                        {% for week in row_weeks %}
+                            <div class="activity_display hidden cell_{{week}}">
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                <div class="spacer20"></div>
+
+                {# row 2 headings #}
+                <div class="row">
+                    {% for month in row_2_months %}
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# row 2 weeks #}
+                <div class="row">
+                    {% for month in row_2_months %}            
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                {# row 2 classes #}
+                <div class="row row_2">
+                    {% for month in row_2_months %}
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                        {% for week in row_weeks %}
+                            <div class="activity_display hidden cell_{{week}}">
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                <div class="spacer20"></div>
+
+                {# row 3 headings #}
+                <div class="row">
+                    {% for month in row_3_months %}
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# row 3 weeks #}
+                <div class="row">
+                    {% for month in row_3_months %}            
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                {# row 3 classes #}
+                <div class="row row_3">
+                    {% for month in row_3_months %}
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                        {% for week in row_weeks %}
+                            <div class="activity_display hidden cell_{{week}}">
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                <div class="spacer20"></div>
+                
+                {# row 4 months #}
+                <div class="row">
+                    {% for month in row_4_months %}
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# row 4 weeks #}
+                <div class="row">
+                    {% for month in row_4_months %}
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                {# row 4 classes #}
+                <div class="row row_4">
+                    {% for month in row_4_months %}
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                        {% for week in row_weeks %}
+                            <div class="activity_display hidden cell_{{week}}">
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                <div class="spacer20"></div>
+                
+                {# row 5 months #}
+                <div class="row">
+                    {% for month in row_5_months %}
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
+                    {% endfor %}
+                </div>
+
+                {# row 5 weeks #}
+                <div class="row">
+                    {% for month in row_5_months %}
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+
+                {# row 5 classes #}
+                <div class="row row_5">
+                    {% for month in row_5_months %}
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                        {% for week in row_weeks %}
+                            <div class="activity_display hidden cell_{{week}}">
+                            </div>
+                        {% endfor %}
+                        </div>
+                    {% endfor %}    
+                </div>
+            </div>
+
+            <div class="content-mobile">
+                {# row 1 months #}
+                
                 {% for month in row_1_months %}
-                    <div class="col-md-4 month center">
-                        {{ month }}
+                    <div class="row">
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="row row_1">
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                            {% for week in row_weeks %}
+                                <div class="activity_display hidden cell_{{week}}">
+                                </div> 
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="spacer20"></div>
                 {% endfor %}
-            </div>
 
-            {# row 1 weeks #}
-            <div class="row">
-                {% for month in row_months %}
-                    <div class="col-md-4 week_block center">
-                    {% for week in row_weeks %}
-                        <div class="week">
-                            {{ week }}
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            {# row 1 classes #}
-            <div class="row row_1">
-                {% for month in row_months %}
-                    <div class="col-md-4 activity_block center month_{{month}}">
-                    {% for week in row_weeks %}
-                        <div class="activity_display hidden cell_{{week}}">
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            <div class="spacer20"></div>
-
-            {# row 2 headings #}
-            <div class="row">
                 {% for month in row_2_months %}
-                    <div class="col-md-4 month center">
-                        {{ month }}
+                    <div class="row">
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="row row_2">
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                            {% for week in row_weeks %}
+                                <div class="activity_display hidden cell_{{week}}">
+                                </div> 
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="spacer20"></div>
                 {% endfor %}
-            </div>
 
-            {# row 2 weeks #}
-            <div class="row">
-                {% for month in row_months %}            
-                    <div class="col-md-4 week_block center">
-                    {% for week in row_weeks %}
-                        <div class="week">
-                            {{ week }}
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            {# row 2 classes #}
-            <div class="row row_2">
-                {% for month in row_months %}
-                    <div class="col-md-4 activity_block center month_{{month}}">
-                    {% for week in row_weeks %}
-                        <div class="activity_display hidden cell_{{week}}">
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            <div class="spacer20"></div>
-
-            {# row 3 headings #}
-            <div class="row">
                 {% for month in row_3_months %}
-                    <div class="col-md-4 month center">
-                        {{ month }}
+                    <div class="row">
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="row row_3">
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                            {% for week in row_weeks %}
+                                <div class="activity_display hidden cell_{{week}}">
+                                </div> 
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="spacer20"></div>
                 {% endfor %}
-            </div>
 
-            {# row 3 weeks #}
-            <div class="row">
-                {% for month in row_months %}            
-                    <div class="col-md-4 week_block center">
-                    {% for week in row_weeks %}
-                        <div class="week">
-                            {{ week }}
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            {# row 3 classes #}
-            <div class="row row_3">
-                {% for month in row_months %}
-                    <div class="col-md-4 activity_block center month_{{month}}">
-                    {% for week in row_weeks %}
-                        <div class="activity_display hidden cell_{{week}}">
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            <div class="spacer20"></div>
-            
-            {# row 4 months #}
-            <div class="row">
                 {% for month in row_4_months %}
-                    <div class="col-md-4 month center">
-                        {{ month }}
+                    <div class="row">
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="row row_4">
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                            {% for week in row_weeks %}
+                                <div class="activity_display hidden cell_{{week}}">
+                                </div> 
+                            {% endfor %}
+                        </div>
+                    </div>
+                    <div class="spacer20"></div>
                 {% endfor %}
-            </div>
 
-            {# row 4 weeks #}
-            <div class="row">
-                {% for month in row_months %}
-                    <div class="col-md-4 week_block center">
-                    {% for week in row_weeks %}
-                        <div class="week">
-                            {{ week }}
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            {# row 4 classes #}
-            <div class="row row_4">
-                {% for month in row_months %}
-                    <div class="col-md-4 activity_block center month_{{month}}">
-                    {% for week in row_weeks %}
-                        <div class="activity_display hidden cell_{{week}}">
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            <div class="spacer20"></div>
-            
-            {# row 5 months #}
-            <div class="row">
                 {% for month in row_5_months %}
-                    <div class="col-md-4 month center">
-                        {{ month }}
+                    <div class="row">
+                        <div class="col-md-4 month center">
+                            {{ month.1 }}
+                        </div>
                     </div>
+                    <div class="row">
+                        <div class="col-md-4 week_block center">
+                        {% for week in row_weeks %}
+                            <div class="week">
+                                {{ week }}
+                            </div>
+                        {% endfor %}
+                        </div>
+                    </div>
+                    <div class="row row_5">
+                        <div class="col-md-4 activity_block center month_{{month.0}}">
+                            {% for week in row_weeks %}
+                                <div class="activity_display hidden cell_{{week}}">
+                                </div> 
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% if month.0 != 3 %}
+                        <div class="spacer20"></div>
+                    {% endif %}
                 {% endfor %}
-            </div>
 
-            {# row 5 weeks #}
-            <div class="row">
-                {% for month in row_months %}
-                    <div class="col-md-4 week_block center">
-                    {% for week in row_weeks %}
-                        <div class="week">
-                            {{ week }}
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
-            {# row 5 classes #}
-            <div class="row row_5">
-                {% for month in row_months %}
-                    <div class="col-md-4 activity_block center month_{{month}}">
-                    {% for week in row_weeks %}
-                        <div class="activity_display hidden cell_{{week}}">
-                        </div>
-                    {% endfor %}
-                    </div>
-                {% endfor %}    
-            </div>
-
+            </div> 
         </div>
 
         {# next, prev navigation #}
-        <div class="row">
+        <div class="row content-desktop">
             <div class="col-md-3">
             </div>
             <div class="col-md-2">
@@ -268,71 +416,146 @@
             </div>
         </div>
 
+        {# next, prev navigation #}
+        <div class="content-mobile">
+            <div class="row">
+                <div class="col-md-2 center">
+                    <a href="#" class="prev_program float-l">&larr; Previous</a>
+                    <span class="program_index">&nbsp;</span>
+                    <a href="#" class="next_program float-r">Next &rarr;</a>
+                </div>
+            </div>
+            <div class="row">
+                <div class="col-md-2" style="display:flex;justify-content: center;">
+                <a role="button" class="btn btn-secondary copy_program txt-w" style="margin-top: 1em;">Copy Schedule</a>
+            </div>
+            </div>
+        </div>
+
         <div class="spacer20"></div>
         <hr>
         <div class="spacer20"></div>
 
         {# data entry section #}
         <div class="container">
-            {# section headings #}
-            <div class="row activity_header">
-                <div class="col-md-1 mb-2">
-                    <h5>Code</h5>
+            <div class="content-desktop">
+                {# section headings #}
+                <div class="row activity_header">
+                    <div class="col-md-1 mb-2">
+                        <h5>Code</h5>
+                    </div>
+                    <div class="col-md-3 mb-2">
+                        <h5>Name</h5>
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <h5>Category</h5>
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <h5>Start weeks</h5>
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <h5></h5>
+                    </div>
+                    <div class="col-md-2 mb-2">
+                        <h5>Length</h5>
+                    </div>
                 </div>
-                <div class="col-md-3 mb-2">
-                    <h5>Name</h5>
-                </div>
-                <div class="col-md-2 mb-2">
-                    <h5>Category</h5>
-                </div>
-                <div class="col-md-2 mb-2">
-                    <h5>Start weeks</h5>
-                </div>
-                <div class="col-md-2 mb-2">
-                    <h5></h5>
-                </div>
-                <div class="col-md-2 mb-2">
-                    <h5>Length</h5>
+
+                {# data inputs #}
+                <div class="activity">
+                    <div class="row">
+                        <div class="col-md-1 mb-4">
+                            <input type="text" class="act_code form-control" style="width:100%;">
+                        </div>
+                        <div class="col-md-3 mb-4">
+                            <input type="text" class="act_name form-control" style="width:100%;">
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <select class="act_category form-control" style="width:100%;">
+                                <option value="" disabled selected>Select...</option>
+                                <option value="Class">Class</option>
+                                <option value="Rotation">Rotation</option>
+                                <option value="Custom">Custom</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <select class="act_slot_selector form-control" multiple>
+                                {% for week in all_weeks %}
+                                    <option value="{{ week }}">{{ week }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <textarea class="form-control selected_slots" disabled></textarea>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <select class="act_length form-control">
+                                <option value="" disabled selected>Select...</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                            </select>
+                            <a href="#" class="close remove_activity hidden">&times;</a>
+                        </div>            
+                    </div>
                 </div>
             </div>
 
-            {# data inputs #}
-            <div class="activity">
-                <div class="row">
-                    <div class="col-md-1 mb-4">
-                        <input type="text" class="act_code form-control" style="width:100%;">
+            <div class="content-mobile">
+                {# data headings and inputs #}
+                <div class="activity">
+                    <div class="row">
+                        <div class="col-md-1 mb-4">
+                            <span class="txt-gold">
+                                <h5>Code</h5>
+                            </span>
+                            <input type="text" class="act_code form-control" style="width:100%;">
+                        </div>
+                        <div class="col-md-3 mb-4">
+                            <span class="txt-gold">
+                                <h5>Name</h5>
+                            </span>
+                            <input type="text" class="act_name form-control" style="width:100%;">
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <span class="txt-gold">
+                                <h5>Category</h5>
+                            </span>
+                            <select class="act_category form-control" style="width:100%;">
+                                <option value="" disabled selected>Select...</option>
+                                <option value="Class">Class</option>
+                                <option value="Rotation">Rotation</option>
+                                <option value="Custom">Custom</option>
+                            </select>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <span class="txt-gold">
+                                <h5>Start weeks</h5>
+                            </span>
+                            <select class="act_slot_selector form-control" multiple>
+                                {% for week in all_weeks %}
+                                    <option value="{{ week }}">{{ week }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <textarea class="form-control selected_slots" disabled></textarea>
+                        </div>
+                        <div class="col-md-2 mb-4">
+                            <span class="txt-gold">
+                                   <h5>Length</h5>
+                               </span>
+                            <select class="act_length form-control">
+                                <option value="" disabled selected>Select...</option>
+                                <option value="1">1</option>
+                                <option value="2">2</option>
+                                <option value="3">3</option>
+                                <option value="4">4</option>
+                            </select>
+                            <a href="#" class="close remove_activity hidden">&times;</a>
+                        </div>            
                     </div>
-                    <div class="col-md-3 mb-4">
-                        <input type="text" class="act_name form-control" style="width:100%;">
-                    </div>
-                    <div class="col-md-2 mb-4">
-                        <select class="act_category form-control" style="width:100%;">
-                            <option value="" disabled selected>Select...</option>
-                            <option value="Class">Class</option>
-                            <option value="Rotation">Rotation</option>
-                            <option value="Custom">Custom</option>
-                        </select>
-                    </div>
-                    <div class="col-md-2 mb-4">
-                        <select class="act_slot_selector form-control" multiple>
-                            {% for week in all_weeks %}
-                                <option value="{{ week }}">{{ week }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
-                    <div class="col-md-2 mb-4">
-                        <textarea class="form-control selected_slots" disabled></textarea>
-                    </div>
-                    <div class="col-md-2 mb-4">
-                        <select class="act_length form-control">
-                            <option value="" disabled selected>Select...</option>
-                            <option value="1">1</option>
-                            <option value="2">2</option>
-                            <option value="3">3</option>
-                            <option value="4">4</option>
-                        </select>
-                        <a href="#" class="close remove_activity hidden">&times;</a>
-                    </div>            
                 </div>
             </div>
 
@@ -349,7 +572,7 @@
         {# generate schedules #}
         <div class="row">
             <div class="col-md-5"></div>
-            <div class="col-md-2">
+            <div class="col-md-2 center">
                 {% csrf_token %}
                 <a role="button" class="btn btn-primary txt-w" id="generate">Generate Schedules</a>
             </div>

--- a/md_scheduler/scheduler/views.py
+++ b/md_scheduler/scheduler/views.py
@@ -9,12 +9,11 @@ import json
 def index(request):
     context = {
         "all_weeks" : [e.name.replace("_", " (") + ")" for e in enums.Weeks],
-        "row_1_months" : ["May - Fall", "June - Fall", "July - Fall"],
-        "row_2_months" : ["August - Fall", "September - Fall", "October - Fall"],
-        "row_3_months" : ["November - Fall", "December - Fall", "January - Spring"],
-        "row_4_months" : ["February - Spring", "March - Spring", "April - Spring"],
-        "row_5_months" : ["May - Spring", "June - Spring", "July - Spring"],
-        "row_months" : [1, 2, 3],
+        "row_1_months" : [[1, "May - Fall"], [2, "June - Fall"], [3, "July - Fall"]],
+        "row_2_months" : [[1, "August - Fall"], [2, "September - Fall"], [3, "October - Fall"]],
+        "row_3_months" : [[1, "November - Fall"], [2, "December - Fall"], [3, "January - Spring"]],
+        "row_4_months" : [[1, "February - Spring"], [2, "March - Spring"], [3, "April - Spring"]],
+        "row_5_months" : [[1, "May - Spring"], [2, "June - Spring"], [3, "July - Spring"]],
         "row_weeks"  : [1, 2, 3, 4], 
     }
 


### PR DESCRIPTION
- Swiping on calendar toggles schedules
- Form titles next to fields on every entry
- One month per row w. all components in order
- Small change to initial backend structure, to accommodate alternative month layout
- Various css changes, including setting mobile/desktop layout
- JS detects mobile/desktop and modifies appropriate elements
- Minor aesthetic changes for mobile ui, specifically with prev/next links and copy button